### PR TITLE
Add sync integration tests

### DIFF
--- a/scripts/notion/AGENTS.md
+++ b/scripts/notion/AGENTS.md
@@ -185,6 +185,8 @@ The test database (specified by `TEST_DATABASE_ID` in `.env.test`) must have the
 | Category | select | Filter tests | Used for select filter tests |
 | Date | date | Filter tests | Used for date filter tests |
 | Description | rich_text | Optional | Used for rich text filter tests |
+| dendron_id | rich_text | Sync tests | Required for `notion sync` integration tests |
+| last_synced | date | Sync tests | Required for `notion sync` integration tests |
 
 **Setup Helper**: Run `node integ/setupTestDatabase.js` to automatically configure your test database with all required properties.
 

--- a/scripts/notion/docs/specs/active/2026-01-31-notion-sync-command.md
+++ b/scripts/notion/docs/specs/active/2026-01-31-notion-sync-command.md
@@ -76,7 +76,7 @@ The CLI currently supports `create`, `list-db`, `sync-meta`, `parse-block`, and 
 ### Phase 3: CLI + Docs + Tests
 - [x] Add `sync` command to `notion.js` and update `USAGE.md` with usage + examples.
 - [x] Add unit tests for frontmatter parsing, rule matching, and property merge helpers.
-- [ ] Validate behavior manually or via integration tests if Notion credentials are available.
+- [x] Validate behavior manually or via integration tests if Notion credentials are available.
 
 **Dependencies between phases:**
 - Phase 2 depends on Phase 1 utilities.

--- a/scripts/notion/docs/specs/active/2026-02-01-notion-sync-integration-tests.md
+++ b/scripts/notion/docs/specs/active/2026-02-01-notion-sync-integration-tests.md
@@ -1,0 +1,127 @@
+# Execution Plan: Notion Sync Integration Tests
+
+**Date:** 2026-02-01
+**Status:** Completed
+
+---
+
+## Goal
+
+Add integration tests for the `notion sync` command that cover single-note sync and full notes-folder sync against the test Notion workspace, ensuring required database properties exist for sync.
+
+---
+
+## Context
+
+### Background
+The sync command is implemented and unit-tested, but integration coverage is missing. The plan for `notion sync` calls for validating behavior via integration tests when Notion credentials are available.
+
+### Current State
+- Integration tests live under `scripts/notion/integ` and use `.env.test` for credentials.
+- `notion sync` reads `syncRules/` and scans `notes/` by default.
+- Test database setup script does not yet enforce sync-required properties (`dendron_id`, `last_synced`).
+
+### Constraints
+- CommonJS Node project using Jest.
+- Integration tests must hit the real Notion API and use the test workspace.
+- CLI uses `process.cwd()` to locate `syncRules` and notes.
+
+---
+
+## Technical Approach
+
+### Architecture/Design
+- Add `integ/sync.test.js` that:
+  - Creates a temporary workspace with `syncRules/` and `notes/`.
+  - Runs `node notion.js sync` via `child_process` with `cwd` pointing at the temp workspace.
+  - Verifies updated frontmatter (`notion_url`, `last_synced`) and that pages exist in Notion.
+
+### Technology Stack
+- Jest integration tests.
+- `@notionhq/client` for verification.
+- Existing `utils` helpers for frontmatter parsing and Notion ID extraction.
+
+### Integration Points
+- Notion API: `pages.create`, `pages.retrieve` via CLI flow.
+- CLI entrypoint `notion.js`.
+
+### Design Patterns
+- Use temp directories for isolation.
+- Reuse existing test env loading (`loadEnv`).
+
+### Important Context
+- Sync requires `dendron_id` (rich_text) and `last_synced` (date) properties in the destination database.
+
+---
+
+## Steps
+
+### Phase 1: Implement Integration Tests
+- [x] Add `integ/sync.test.js` covering:
+  - Sync a single note via positional target.
+  - Sync all notes in a `notes/` folder.
+- [x] Use test workspace credentials from `.env.test`.
+
+### Phase 2: Test Database + Docs Updates
+- [x] Update `integ/setupTestDatabase.js` to include `dendron_id` and `last_synced` properties.
+- [x] Update relevant docs/spec status to reflect integration coverage.
+
+**Dependencies between phases:**
+- Phase 2 can follow Phase 1; tests depend on database properties being present.
+
+---
+
+## Testing
+
+- `npx jest integ/sync.test.js`
+
+---
+
+## Dependencies
+
+### External Services/APIs
+- Notion API: create/update/retrieve pages.
+
+### Libraries/Packages
+- `@notionhq/client`, `jest` (already in repo).
+
+### Tools/Infrastructure
+- Notion integration token in `.env.test`.
+
+### Access Required
+- [ ] `NOTION_TOKEN` (or `NOTION_API_KEY`) in `.env.test`.
+- [ ] `TEST_DATABASE_ID` in `.env.test`.
+
+---
+
+## Risks & Mitigations
+
+| Risk | Impact | Probability | Mitigation Strategy |
+|------|--------|-------------|---------------------|
+| Test database missing sync properties | High | Medium | Extend setup script to ensure properties exist |
+| Notion API rate limits | Medium | Low | Keep tests minimal, use small note counts |
+| Flaky tests due to network latency | Medium | Low | Increase Jest timeouts |
+
+---
+
+## Questions
+
+### Technical Decisions Needed
+- [x] Use `TEST_DATABASE_ID` for sync tests (no separate sync DB required).
+
+### Clarifications Required
+- [x] Integration tests should run via CLI to cover note discovery and rule loading.
+
+---
+
+## Success Criteria
+
+- [x] Integration tests for `notion sync` cover single-note and notes-folder sync.
+- [x] Tests run against the test Notion workspace and pass reliably.
+- [x] Test database setup script ensures required sync properties.
+
+---
+
+## Notes
+
+- Extends the `2026-01-31-notion-sync-command` plan with integration coverage.

--- a/scripts/notion/integ/setupTestDatabase.js
+++ b/scripts/notion/integ/setupTestDatabase.js
@@ -102,6 +102,14 @@ const REQUIRED_PROPERTIES = {
     type: 'rich_text',
     rich_text: {},
   },
+  dendron_id: {
+    type: 'rich_text',
+    rich_text: {},
+  },
+  last_synced: {
+    type: 'date',
+    date: {},
+  },
 };
 
 async function setupTestDatabase() {

--- a/scripts/notion/integ/sync.test.js
+++ b/scripts/notion/integ/sync.test.js
@@ -1,0 +1,191 @@
+const { Client } = require('@notionhq/client');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { spawnSync } = require('child_process');
+const {
+  loadEnv,
+  parseFrontmatter,
+  serializeFrontmatter,
+  extractNotionIdFromUrl,
+  normalizeNotionId,
+} = require('../utils');
+
+// Set NODE_ENV to test so loadEnv loads .env.test
+process.env.NODE_ENV = 'test';
+
+// Load .env.test using the loadEnv utility
+try {
+  loadEnv();
+} catch (err) {
+  throw new Error(`Failed to load .env.test: ${err.message}`);
+}
+
+jest.setTimeout(45000);
+
+describe('Sync Command Integration Tests', () => {
+  let client;
+  let testDatabaseId;
+  const notionCliPath = path.resolve(__dirname, '..', 'notion.js');
+
+  beforeAll(() => {
+    const token = process.env.NOTION_TOKEN;
+    if (!token) {
+      throw new Error('NOTION_TOKEN must be set in .env.test for integration tests');
+    }
+    client = new Client({ auth: token });
+
+    testDatabaseId = process.env.TEST_DATABASE_ID;
+    if (!testDatabaseId) {
+      throw new Error('TEST_DATABASE_ID not set in .env.test');
+    }
+  });
+
+  const uniqueSuffix = () => `${Date.now()}-${Math.random().toString(16).slice(2, 10)}`;
+
+  const createTempWorkspace = () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'notion-sync-'));
+    const syncRulesDir = path.join(root, 'syncRules');
+    const notesDir = path.join(root, 'notes');
+
+    fs.mkdirSync(syncRulesDir, { recursive: true });
+    fs.mkdirSync(notesDir, { recursive: true });
+
+    const ruleContent = `module.exports = {
+  fnameTrigger: 'task.*',
+  fmToSync: [
+    { name: 'title', target: 'Name' },
+    { name: 'proj', target: 'Tags', mode: 'append' },
+  ],
+  destination: {
+    databaseId: '${testDatabaseId}',
+  },
+};\n`;
+
+    fs.writeFileSync(path.join(syncRulesDir, 'task.js'), ruleContent, 'utf8');
+
+    const cleanup = () => {
+      fs.rmSync(root, { recursive: true, force: true });
+    };
+
+    return { root, notesDir, cleanup };
+  };
+
+  const writeNote = ({ notesDir, fname, title, proj, body }) => {
+    const frontmatter = {
+      id: `sync-${uniqueSuffix()}`,
+      title,
+      proj,
+      fname,
+    };
+
+    const content = serializeFrontmatter(frontmatter, body);
+    const filePath = path.join(notesDir, `${fname}.md`);
+    fs.writeFileSync(filePath, content, 'utf8');
+    return filePath;
+  };
+
+  const runSyncCommand = ({ cwd, args = [] }) => {
+    const result = spawnSync('node', [notionCliPath, 'sync', ...args], {
+      cwd,
+      env: { ...process.env },
+      encoding: 'utf8',
+    });
+
+    if (result.error) {
+      throw result.error;
+    }
+
+    if (result.status !== 0) {
+      const output = result.stderr || result.stdout || '';
+      throw new Error(`sync command failed (${result.status}): ${output}`);
+    }
+
+    return result.stdout || '';
+  };
+
+  const readFrontmatter = (filePath) => {
+    const raw = fs.readFileSync(filePath, 'utf8');
+    return parseFrontmatter(raw);
+  };
+
+  const expectSyncedFrontmatter = (parsed) => {
+    expect(parsed.hasFrontmatter).toBe(true);
+    expect(parsed.data.notion_url).toBeTruthy();
+    expect(parsed.data.last_synced).toMatch(/\d{4}-\d{2}-\d{2} \d{2}:\d{2}/);
+    return parsed.data.notion_url;
+  };
+
+  const fetchPage = async (notionUrl) => {
+    const rawId = extractNotionIdFromUrl(notionUrl);
+    expect(rawId).toBeTruthy();
+
+    const pageId = normalizeNotionId(rawId);
+    const page = await client.pages.retrieve({ page_id: pageId });
+    expect(page).toBeDefined();
+    return page;
+  };
+
+  test('syncs a single note', async () => {
+    const workspace = createTempWorkspace();
+
+    try {
+      const fname = `task.sync-one-${uniqueSuffix()}`;
+      const notePath = writeNote({
+        notesDir: workspace.notesDir,
+        fname,
+        title: `Sync One ${uniqueSuffix()}`,
+        proj: 'test',
+        body: 'Integration test body for sync one.',
+      });
+
+      const stdout = runSyncCommand({ cwd: workspace.root, args: [notePath] });
+      expect(stdout).toMatch(/Sync complete/);
+
+      const parsed = readFrontmatter(notePath);
+      const notionUrl = expectSyncedFrontmatter(parsed);
+
+      const page = await fetchPage(notionUrl);
+      expect(page.properties).toHaveProperty('dendron_id');
+      expect(page.properties).toHaveProperty('last_synced');
+    } finally {
+      workspace.cleanup();
+    }
+  });
+
+  test('syncs all notes in the notes folder', async () => {
+    const workspace = createTempWorkspace();
+
+    try {
+      const noteA = writeNote({
+        notesDir: workspace.notesDir,
+        fname: `task.sync-all-a-${uniqueSuffix()}`,
+        title: `Sync All A ${uniqueSuffix()}`,
+        proj: 'test',
+        body: 'Integration test body for sync all A.',
+      });
+
+      const noteB = writeNote({
+        notesDir: workspace.notesDir,
+        fname: `task.sync-all-b-${uniqueSuffix()}`,
+        title: `Sync All B ${uniqueSuffix()}`,
+        proj: 'test',
+        body: 'Integration test body for sync all B.',
+      });
+
+      const stdout = runSyncCommand({ cwd: workspace.root });
+      expect(stdout).toMatch(/Sync complete/);
+
+      const parsedA = readFrontmatter(noteA);
+      const parsedB = readFrontmatter(noteB);
+
+      const urlA = expectSyncedFrontmatter(parsedA);
+      const urlB = expectSyncedFrontmatter(parsedB);
+
+      await fetchPage(urlA);
+      await fetchPage(urlB);
+    } finally {
+      workspace.cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add sync command integration tests for single-note and notes-folder sync
- ensure test database setup includes dendron_id and last_synced
- update sync command spec status and test database requirements

## Testing
- npx jest integ/sync.test.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated test database schema specifications with new required properties for Notion sync integration.
* Added comprehensive integration testing plan for the Notion sync feature.

## Tests
* Implemented new integration test suite to validate Notion sync functionality against a live Notion workspace.
* Tests cover single-note and folder-wide sync operations with frontmatter validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->